### PR TITLE
chat_spaceに自動更新機能を実装しました

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -73,7 +73,6 @@ $(function(){
       data: {id: last_message_id}
     })
     .done(function(messages) {
-      console.log(messages)
         if (messages.length !== 0) {
         var insertHTML = '';
         $.each(messages, function(i, message) {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
     if ( message.image ) {
       var html =
-        `<div class="chat_main__message--list_name_date_message">
+        `<div class="chat_main__message--list_name_date_message" data-message-id=${message.id}>
           <div class="chat_main__message--list_name_date_message_name_date">
             <div class="chat_main__message--list_name_date_message_name_date_name">
               ${message.user_name}
@@ -21,7 +21,7 @@ $(function(){
       return html;
     } else {
       var html =
-        `<div class="chat_main__message--list_name_date_message">
+        `<div class="chat_main__message--list_name_date_message" data-message-id=${message.id}>
           <div class="chat_main__message--list_name_date_message_name_date">
             <div class="chat_main__message--list_name_date_message_name_date_name">
               ${message.user_name}
@@ -60,8 +60,34 @@ $(function(){
     .fail(function() {
       alert("メッセージ送信に失敗しました");
     });
-
     return false;
-    
   });
+  var reloadMessages = function() {
+    console.log(reloadMessages)
+    var last_message_id = $('.chat_main__message--list_name_date_message:last').data("message-id");
+    console.log(last_message_id)
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      console.log(messages)
+        if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.chat_main__message--list').append(insertHTML);
+        $('.chat_main__message--list').animate({ scrollTop: $('.chat_main__message--list')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -8,7 +8,6 @@ $(function() {
     `;
     $("#user-search-result").append(html);
   }
-
   function addNoUser() {
     let html = `
       <div class="chat-group-user clearfix">
@@ -37,22 +36,21 @@ $(function() {
       data: { keyword: input },
       dataType: "json"
     })
-      .done(function(users) {
-        $("#user-search-result").empty();
-
-        if (users.length !== 0) {
-          users.forEach(function(user) {
-            addUser(user);
-          });
-        } else if (input.length == 0) {
-          return false;
-        } else {
-          addNoUser();
-        }
-      })
-      .fail(function() {
-        alert("通信エラーです。ユーザーが表示できません。");
-      });
+    .done(function(users) {
+      $("#user-search-result").empty();
+      if (users.length !== 0) {
+        users.forEach(function(user) {
+          addUser(user);
+        });
+      } else if (input.length == 0) {
+        return false;
+      } else {
+        addNoUser();
+      }
+    })
+    .fail(function() {
+      alert("通信エラーです。ユーザーが表示できません。");
+    });
   });
   $(document).on("click", ".chat-group-user__btn--add", function() {
     console.log

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.chat_main__message--list_name_date_message
+.chat_main__message--list_name_date_message{"data-message-id": "#{message.id}"}
   .chat_main__message--list_name_date_message_name_date
     .chat_main__message--list_name_date_message_name_date_name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#What
チャット画面が自動で更新されるようにしました。
ブラウザでchat_spaceを左右に2画面開き、左のユーザーが投稿すると、右側のユーザーのブラウザで操作することなくメッセージの追加が行われています。

#Why
快適にチャットができるようになります。
毎回リロードしなくても相手からのメッセージが表示されるようになり、快適にチャットができるようになります。